### PR TITLE
Fancyauth.API.DB

### DIFF
--- a/Fancyauth.API.DB/Fancyauth.API.DB.csproj
+++ b/Fancyauth.API.DB/Fancyauth.API.DB.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Fancyauth.API.DB</RootNamespace>
+    <AssemblyName>Fancyauth.API.DB</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IFancyContextProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Fancyauth.Model\Fancyauth.Model.csproj">
+      <Project>{a935cbc9-42bb-4fd6-a8dc-1f8c52c0b89e}</Project>
+      <Name>Fancyauth.Model</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Fancyauth.API.DB/IFancyContextProvider.cs
+++ b/Fancyauth.API.DB/IFancyContextProvider.cs
@@ -1,0 +1,14 @@
+﻿using Fancyauth.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fancyauth.API.DB
+{
+    public interface IFancyContextProvider
+    {
+        Task<FancyContextBase> Connect();
+    }
+}

--- a/Fancyauth.API.DB/Properties/AssemblyInfo.cs
+++ b/Fancyauth.API.DB/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden 
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die mit einer Assembly verknüpft sind.
+[assembly: AssemblyTitle("Fancyauth.API.DB")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Fancyauth.API.DB")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
+// für COM-Komponenten.  Wenn Sie auf einen Typ in dieser Assembly von 
+// COM zugreifen müssen, legen Sie das ComVisible-Attribut für diesen Typ auf "true" fest.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("8cc8506f-80a7-410c-bfc4-f9488babad9a")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion 
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
+// übernehmen, indem Sie "*" eingeben:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Fancyauth.sln
+++ b/Fancyauth.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fancyauth.APIUtil", "Fancya
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fancyauth.Model", "Fancyauth.Model\Fancyauth.Model.csproj", "{A935CBC9-42BB-4FD6-A8DC-1F8C52C0B89E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fancyauth.API.DB", "Fancyauth.API.DB\Fancyauth.API.DB.csproj", "{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +56,14 @@ Global
 		{A935CBC9-42BB-4FD6-A8DC-1F8C52C0B89E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A935CBC9-42BB-4FD6-A8DC-1F8C52C0B89E}.Release|x86.ActiveCfg = Release|Any CPU
 		{A935CBC9-42BB-4FD6-A8DC-1F8C52C0B89E}.Release|x86.Build.0 = Release|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Debug|x86.Build.0 = Debug|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Release|x86.ActiveCfg = Release|Any CPU
+		{8CC8506F-80A7-410C-BFC4-F9488BABAD9A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Fancyauth/Fancyauth.csproj
+++ b/Fancyauth/Fancyauth.csproj
@@ -150,6 +150,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Fancyauth.API.DB\Fancyauth.API.DB.csproj">
+      <Project>{8cc8506f-80a7-410c-bfc4-f9488babad9a}</Project>
+      <Name>Fancyauth.API.DB</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Fancyauth.API\Fancyauth.API.csproj">
       <Project>{F77D8A2C-60EA-4A5A-B9F6-47926B469095}</Project>
       <Name>Fancyauth.API</Name>

--- a/Fancyauth/Plugins/Builtin/Invites.cs
+++ b/Fancyauth/Plugins/Builtin/Invites.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.ComponentModel.Composition;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Fancyauth.API;
+using Fancyauth.API.DB;
 using Fancyauth.APIUtil;
 using Fancyauth.Model;
 
@@ -24,6 +26,9 @@ namespace Fancyauth.Plugins.Builtin
                     throw new Exception("bit gap in PwdIndexMask");
         }
 
+        [Import]
+        public IFancyContextProvider ContextProvider { get; set; }
+
         [Command]
         public async Task Invite(IUser usr)
         {
@@ -34,8 +39,8 @@ namespace Fancyauth.Plugins.Builtin
                 codeBuilder.Append(PwdChars[rand[i] & PwdIndexMask]);
 
             var code = codeBuilder.ToString();
-            using (var context = await FancyContext.Connect()) {
-                context.Invites.Add(new Model.Invite {
+            using (var context = await ContextProvider.Connect()) {
+                context.Invites.Add(new Invite {
                     Code = code,
                     Inviter = context.Users.Attach(new Model.User { Id = usr.UserId }),
                     ExpirationDate = DateTimeOffset.Now.AddHours(1),

--- a/Fancyauth/Plugins/PluginManager.cs
+++ b/Fancyauth/Plugins/PluginManager.cs
@@ -11,6 +11,8 @@ using Fancyauth.API.Commands;
 using Fancyauth.API.ContextCallbacks;
 using Fancyauth.Commands;
 using Fancyauth.ContextCallbacks;
+using Fancyauth.API.DB;
+using Fancyauth.Model;
 
 namespace Fancyauth.Plugins
 {
@@ -90,6 +92,15 @@ namespace Fancyauth.Plugins
             var apiUser = new UserWrapper(WServer, user);
             var destChans = message.channels.Select(x => new ChannelShim(WServer, x)).ToArray();
             return Task.WhenAll(Plugins.Select(x => x.OnChatMessage(apiUser, destChans, message.text)));
+        }
+
+        [Export(typeof(IFancyContextProvider))]
+        internal class FancyContextProvider : IFancyContextProvider
+        {
+            async Task<FancyContextBase> IFancyContextProvider.Connect()
+            {
+                return await FancyContext.Connect();
+            }
         }
     }
 }


### PR DESCRIPTION
We can split off parts of our API like this to preserve reusability.

Putting Steam integration into Fancyauth.API was a mistake. I'm going to revert/not commit that because Fancyauth.API is (should be, imo) intended as nothing more than a general purpose murmur API, _without_ all our fancier bells and whistles (like Steam integration).

We're already using MEF to inject the necessary interfaces, and it works seamlessly with these API extensions. Plugins that require APIs we're not offering simply won't get loaded.

TODO: decide whether silent failure is appropriate here (we probably don't care)

There should be no hard requirements for any plugin to be a builtin. Third party plugins should be able to do just as much as builtins. We'll probably still keep most of our current builtins, simply because the maintainability overhead of managing separate projects is not worth the benefits (none).

If this project ever grows (aka: somebody else starts using it), we need to rethink this decision, simply because people might want to disable builtins like @fancy-ng text.

@EHVAG/fancyauth Feedback required. `Builtin/Invites` shows how plugins can use this.